### PR TITLE
Migrate from HTTParty to Faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in google-amp-cache.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
-desc "Run tests"
+desc 'Run tests'
 
 task default: :test

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "google/amp/cache"
+require 'bundler/setup'
+require 'google/amp/cache'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "google/amp/cache"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/google-amp-cache.gemspec
+++ b/google-amp-cache.gemspec
@@ -1,30 +1,31 @@
+# frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "google/amp/cache/version"
+require 'google/amp/cache/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "google-amp-cache"
+  spec.name          = 'google-amp-cache'
   spec.version       = Google::AMP::Cache::VERSION
-  spec.authors       = ["Richard Lee"]
-  spec.email         = ["rl@polydice.com"]
+  spec.authors       = ['Richard Lee']
+  spec.email         = ['rl@polydice.com']
 
-  spec.summary       = %q{A Ruby wrapper for Google AMP Cache API}
+  spec.summary       = 'A Ruby wrapper for Google AMP Cache API'
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/polydice/google-amp-cache"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/polydice/google-amp-cache'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "faraday_middleware", "~> 1.0"
-  spec.add_runtime_dependency "faraday", "~> 1.0"
-  spec.add_runtime_dependency "rack"
+  spec.add_runtime_dependency 'faraday', '~> 1.0'
+  spec.add_runtime_dependency 'faraday_middleware', '~> 1.0'
+  spec.add_runtime_dependency 'rack'
 
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "minitest", "~> 5.3"
-  spec.add_development_dependency "minitest-reporters", "~> 1.2"
+  spec.add_development_dependency 'minitest', '~> 5.3'
+  spec.add_development_dependency 'minitest-reporters', '~> 1.2'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end

--- a/google-amp-cache.gemspec
+++ b/google-amp-cache.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "multi_json", "~> 1.3"
-  spec.add_runtime_dependency "httparty", ">= 0.7.6"
+  spec.add_runtime_dependency "faraday_middleware", "~> 1.0"
+  spec.add_runtime_dependency "faraday", "~> 1.0"
   spec.add_runtime_dependency "rack"
 
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/google/amp/cache.rb
+++ b/lib/google/amp/cache.rb
@@ -1,2 +1,4 @@
-require "google/amp/cache/version"
-require "google/amp/cache/client"
+# frozen_string_literal: true
+
+require 'google/amp/cache/version'
+require 'google/amp/cache/client'

--- a/lib/google/amp/cache.rb
+++ b/lib/google/amp/cache.rb
@@ -1,5 +1,2 @@
-require "multi_json"
-require "httparty"
-
 require "google/amp/cache/version"
 require "google/amp/cache/client"

--- a/lib/google/amp/cache/client.rb
+++ b/lib/google/amp/cache/client.rb
@@ -1,67 +1,73 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'faraday_middleware'
 require 'base64'
 require 'uri'
 require 'openssl'
 
-module Google::AMP::Cache
-  class Client
-    UPDATE_CACHE_API_DOMAIN_SUFFIX = 'cdn.ampproject.org'
-    DIGEST = OpenSSL::Digest::SHA256.new
+module Google
+  module AMP
+    module Cache
+      class Client
+        UPDATE_CACHE_API_DOMAIN_SUFFIX = 'cdn.ampproject.org'
+        DIGEST = OpenSSL::Digest::SHA256.new
 
-    attr_reader :private_key, :google_api_key
+        attr_reader :private_key, :google_api_key
 
-    def initialize(api_key = nil, private_key = nil)
-      @google_api_key = api_key
-      @private_key = OpenSSL::PKey::RSA.new(private_key) if private_key
-    end
+        def initialize(api_key = nil, private_key = nil)
+          @google_api_key = api_key
+          @private_key = OpenSSL::PKey::RSA.new(private_key) if private_key
+        end
 
-    def batch_get(urls, lookup_strategy = :FETCH_LIVE_DOC)
-      Faraday.new('https://acceleratedmobilepageurl.googleapis.com/',
-                  headers: {
-                      "X-Goog-Api-Key" => google_api_key
-                  }) do |conn|
-        conn.request :json
-        conn.response :json
-        conn.response :raise_error
-      end.post('/v1/ampUrls:batchGet', {
-          urls: Array(urls),
-          lookupStrategy: lookup_strategy
-      }).body
-    end
+        def batch_get(urls, lookup_strategy = :FETCH_LIVE_DOC)
+          Faraday.new('https://acceleratedmobilepageurl.googleapis.com/',
+                      headers: {
+                        'X-Goog-Api-Key' => google_api_key
+                      }) do |conn|
+            conn.request :json
+            conn.response :json
+            conn.response :raise_error
+          end.post('/v1/ampUrls:batchGet', {
+                     urls: Array(urls),
+                     lookupStrategy: lookup_strategy
+                   }).body
+        end
 
-    def update_cache(url, content_type = :document)
-      page_uri = URI.parse(url)
-      subdomain = format_domain(page_uri.host)
+        def update_cache(url, content_type = :document)
+          page_uri = URI.parse(url)
+          subdomain = format_domain(page_uri.host)
 
-      path_components = ["update-cache", short_content_type(content_type)]
-      path_components << 's' if page_uri.scheme.match?('https')
-      path_components << "#{page_uri.host}#{page_uri.path}"
-      path = path_components.join('/')
+          path_components = ['update-cache', short_content_type(content_type)]
+          path_components << 's' if page_uri.scheme.match?('https')
+          path_components << "#{page_uri.host}#{page_uri.path}"
+          path = path_components.join('/')
 
-      params = Faraday::Utils::ParamsHash[{ amp_action: 'flush', amp_ts: Time.now.to_i }]
+          params = Faraday::Utils::ParamsHash[{ amp_action: 'flush', amp_ts: Time.now.to_i }]
 
-      sig = private_key.sign(DIGEST, "/#{path}?#{params.to_query}")
-      params[:amp_url_signature] = Base64.urlsafe_encode64(sig)
+          sig = private_key.sign(DIGEST, "/#{path}?#{params.to_query}")
+          params[:amp_url_signature] = Base64.urlsafe_encode64(sig)
 
-      Faraday.new("https://#{subdomain}.cdn.ampproject.org/") do |conn|
-        conn.response :raise_error
-      end.get(path, params).body
-    end
+          Faraday.new("https://#{subdomain}.cdn.ampproject.org/") do |conn|
+            conn.response :raise_error
+          end.get(path, params).body
+        end
 
-    def short_content_type(type)
-      case type.to_sym
-      when :document
-        'c'
-      when :image
-        'i'
-      when :resource
-        'r'
+        def short_content_type(type)
+          case type.to_sym
+          when :document
+            'c'
+          when :image
+            'i'
+          when :resource
+            'r'
+          end
+        end
+
+        def format_domain(url)
+          url.gsub('-', '--').tr('.', '-')
+        end
       end
-    end
-
-    def format_domain(url)
-      url.gsub('-', '--').tr('.', '-')
     end
   end
 end

--- a/lib/google/amp/cache/version.rb
+++ b/lib/google/amp/cache/version.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Google
   module AMP
     module Cache
-      VERSION = "0.1.0"
+      VERSION = '0.1.0'
     end
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -28,7 +28,7 @@ class ClientMinitest < Minitest::Test
     end
 
     it 'flushes cache' do
-      assert @client.update_cache('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0')
+      assert_equal @client.update_cache('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0'), 'OK'
     end
   end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './test_helper'
 
 class ClientMinitest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 
 require 'minitest/autorun'
 require 'minitest/spec'
-require "minitest/reporters"
+require 'minitest/reporters'
 Minitest::Reporters.use!
 
-$:.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'google/amp/cache'


### PR DESCRIPTION
In this pull request, I rewrote the current implementation to migrate our HTTP client from HTTParty to [Faraday](https://github.com/lostisland/faraday). 

There're two reasons:
1. Faraday is more actively maintained by its maintainers
2. There're many easy-to–use middlewares for faraday

I also applied Rubocop in this PR to make code styles consistent.