### PR TITLE
Enable Rubocop to make maintenance easier

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+require:
+  - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-minitest
+  - rubocop-thread_safety
+
+AllCops:
+  NewCops: enable
+
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/MethodLength:
+  Max: 15
+
+Style/Documentation:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ rvm:
   - 2.6
   - 2.5
   - 2.4
+
+script:
+  - bundle exec rubocop --parallel
+  - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,12 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in google-amp-cache.gemspec
 gemspec
+
+group :rubocop do
+  gem 'rubocop', '>= 0.90', require: false
+  gem 'rubocop-minitest', require: false
+  gem 'rubocop-packaging', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-thread_safety', require: false
+end

--- a/google-amp-cache.gemspec
+++ b/google-amp-cache.gemspec
@@ -10,15 +10,17 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Richard Lee']
   spec.email         = ['rl@polydice.com']
 
+  spec.required_ruby_version = '>= 2.4.0'
+
   spec.summary       = 'A Ruby wrapper for Google AMP Cache API'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/polydice/google-amp-cache'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = Dir['lib/**/*', 'LICENSE.txt', 'CHANGELOG.md', 'README.md']
+  spec.test_files    = Dir['test/**/*', 'Rakefile']
+  spec.executables   = Dir.glob('bin/*').map { |f| File.basename(f) }
+
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'faraday', '~> 1.0'

--- a/lib/google/amp/cache/client.rb
+++ b/lib/google/amp/cache/client.rb
@@ -11,7 +11,13 @@ module Google
     module Cache
       class Client
         UPDATE_CACHE_API_DOMAIN_SUFFIX = 'cdn.ampproject.org'
-        DIGEST = OpenSSL::Digest::SHA256.new
+        DIGEST = OpenSSL::Digest.new('SHA256')
+
+        CONTENT_TYPE_MAPPING = {
+          document: 'c',
+          image: 'i',
+          resource: 'r'
+        }.freeze
 
         attr_reader :private_key, :google_api_key
 
@@ -54,14 +60,7 @@ module Google
         end
 
         def short_content_type(type)
-          case type.to_sym
-          when :document
-            'c'
-          when :image
-            'i'
-          when :resource
-            'r'
-          end
+          CONTENT_TYPE_MAPPING.fetch(type.to_sym, :c)
         end
 
         def format_domain(url)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -6,29 +6,29 @@ class ClientMinitest < Minitest::Test
   describe '#format_domain' do
     it 'replaces - with --' do
       client = Google::AMP::Cache::Client.new(nil)
-      assert_equal client.format_domain('pub-pub.com'), 'pub--pub-com'
+      assert_equal('pub--pub-com', client.format_domain('pub-pub.com'))
     end
 
     it 'reaplces . with .' do
       client = Google::AMP::Cache::Client.new(nil)
-      assert_equal client.format_domain('pub.com'), 'pub-com'
+      assert_equal('pub-com', client.format_domain('pub.com'))
     end
   end
 
   describe '#short_content_type' do
     it 'converts content type for document' do
       client = Google::AMP::Cache::Client.new(nil)
-      assert_equal client.short_content_type(:document), 'c'
+      assert_equal('c', client.short_content_type(:document))
     end
   end
 
   describe '#update_cache' do
     before do
-      @client = Google::AMP::Cache::Client.new(nil, File.read(File.dirname(__FILE__) + '/private-key.pem'))
+      @client = Google::AMP::Cache::Client.new(nil, File.read("#{File.dirname(__FILE__)}/private-key.pem"))
     end
 
     it 'flushes cache' do
-      assert_equal @client.update_cache('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0'), 'OK'
+      assert_equal('OK', @client.update_cache('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0'))
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'bundler/setup'
-
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/reporters'


### PR DESCRIPTION
## What's Changed

### Rubocop 🚨 
- Add Rubocop to `:rubocop` group of Gemfile
- Add following Rubocop extensions
  - rubocop-packaging
  - rubocop-performance
  - rubocop-rails
  - rubocop-minitest
  - rubocop-thread_safety
- Enable Rubocop Inspection to Travis CI

### Gemspec
- Mark required Ruby version in gemspec
- Stop depending Git to gather files in gemspec

### Code Readability
- Remove require `bundle/setup` in test helper
- Revise `Client#short_content_type` with Hash lookup
