### PR TITLE
Split AMP invalidate request to Invalidator and expose cache domain config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,6 @@
 require:
   - rubocop-packaging
   - rubocop-performance
-  - rubocop-rails
   - rubocop-minitest
   - rubocop-thread_safety
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,7 @@ Metrics/MethodLength:
 
 Style/Documentation:
   Enabled: false
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,5 @@ group :rubocop do
   gem 'rubocop-minitest', require: false
   gem 'rubocop-packaging', require: false
   gem 'rubocop-performance', require: false
-  gem 'rubocop-rails', require: false
   gem 'rubocop-thread_safety', require: false
 end

--- a/google-amp-cache.gemspec
+++ b/google-amp-cache.gemspec
@@ -30,4 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.3'
   spec.add_development_dependency 'minitest-reporters', '~> 1.2'
   spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'timecop', '~> 0.9.1'
+  spec.add_development_dependency 'webmock', '~> 3.9.1'
 end

--- a/lib/google/amp/cache.rb
+++ b/lib/google/amp/cache.rb
@@ -2,3 +2,5 @@
 
 require 'google/amp/cache/version'
 require 'google/amp/cache/client'
+require 'google/amp/cache/invalidator'
+require 'google/amp/cache/errors'

--- a/lib/google/amp/cache/configuration.rb
+++ b/lib/google/amp/cache/configuration.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Google
+  module AMP
+    module Cache
+      class Configuration
+        attr_accessor :private_key, :amp_cache_domain
+
+        def initialize
+          @amp_cache_domain = 'cdn.ampproject.org'
+        end
+      end
+
+      # rubocop:disable ThreadSafety/InstanceVariableInClassMethod
+      def self.configuration
+        @configuration ||= Configuration.new
+      end
+      # rubocop:enable ThreadSafety/InstanceVariableInClassMethod
+
+      def self.configure
+        yield configuration
+      end
+    end
+  end
+end

--- a/lib/google/amp/cache/errors.rb
+++ b/lib/google/amp/cache/errors.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Google
+  module AMP
+    module Cache
+      class PrivateKeyNotFound < StandardError
+        def initialize(msg = 'Please ensure private key is properly configured to sign AMP update-cache requests')
+          super(msg)
+        end
+      end
+
+      class ForbiddenError < StandardError
+        def initialize(msg = 'Request Forbidden', response = nil)
+          @response = response
+          super(msg)
+        end
+      end
+    end
+  end
+end

--- a/lib/google/amp/cache/invalidator.rb
+++ b/lib/google/amp/cache/invalidator.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require_relative './signatory'
+require_relative './errors'
+
+module Google
+  module AMP
+    module Cache
+      class Invalidator
+        CONTENT_TYPE_MAPPING = {
+          document: :c,
+          image: :i,
+          resource: :r
+        }.freeze
+
+        PROTOCOL_MAPPING = {
+          https: :s,
+          http: nil
+        }.freeze
+
+        def initialize(url, content_type: :document)
+          @url = url
+          @content_type = CONTENT_TYPE_MAPPING.fetch(content_type.to_sym, :c)
+        end
+
+        def ping
+          response = Net::HTTP.get_response(signed_uri)
+
+          case response.code.to_i
+          when 200
+            response.body
+          when 403
+            # rubocop:disable Layout/LineLength
+            raise Google::AMP::Cache::ForbiddenError, 'Invalidate request forbidden, ensure you have private key and public properly configured'
+            # rubocop:enable Layout/LineLength
+          else
+            raise response
+          end
+        end
+
+        private
+
+        def signed_uri
+          @signed_uri = update_cache_uri
+          @signed_uri.query = URI.encode_www_form(signed_params)
+          @signed_uri
+        end
+
+        def uri
+          URI.parse(@url)
+        end
+
+        def request_params
+          @request_params ||= {
+            amp_action: :flush,
+            amp_ts: Time.now.to_i
+          }
+        end
+
+        def signed_params
+          @signed_params ||= request_params.merge(
+            amp_url_signature: Base64.urlsafe_encode64(signature, padding: false)
+          )
+        end
+
+        def signature
+          Google::AMP::Cache::Signatory.new(update_cache_uri.request_uri).sign
+        end
+
+        def protocol
+          PROTOCOL_MAPPING.fetch(uri.scheme, :s)
+        end
+
+        def request_path
+          Pathname.new('/update-cache').join(
+            @content_type.to_s,
+            protocol.to_s,
+            uri.host,
+            Pathname.new(uri.path).relative_path_from(Pathname.new(uri.path.empty? ? '' : '/'))
+          )
+        end
+
+        def update_cache_uri
+          return @update_cache_uri if @update_cache_uri
+
+          @update_cache_uri = URI.parse(['https://', cache_host, request_path].join)
+          @update_cache_uri.query = URI.encode_www_form(request_params)
+          @update_cache_uri
+        end
+
+        def cache_domain
+          Google::AMP::Cache.configuration.amp_cache_domain
+        end
+
+        def cache_subdomain
+          uri.host.gsub('-', '--').tr('.', '-')
+        end
+
+        def cache_host
+          [cache_subdomain, cache_domain].join('.')
+        end
+      end
+    end
+  end
+end

--- a/lib/google/amp/cache/invalidator.rb
+++ b/lib/google/amp/cache/invalidator.rb
@@ -24,7 +24,7 @@ module Google
           @content_type = CONTENT_TYPE_MAPPING.fetch(content_type.to_sym, :c)
         end
 
-        def ping
+        def update_cache
           response = Net::HTTP.get_response(signed_uri)
 
           case response.code.to_i

--- a/lib/google/amp/cache/signatory.rb
+++ b/lib/google/amp/cache/signatory.rb
@@ -22,7 +22,7 @@ module Google
         private
 
         def signer
-          raise Google::AMP::Cache::PrivateKeyNotFound if private_key.blank?
+          raise Google::AMP::Cache::PrivateKeyNotFound if private_key.nil? || private_key.empty?
 
           OpenSSL::PKey::RSA.new(private_key)
         end

--- a/lib/google/amp/cache/signatory.rb
+++ b/lib/google/amp/cache/signatory.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'fileutils'
+require_relative './configuration'
+require_relative './errors'
+
+module Google
+  module AMP
+    module Cache
+      class Signatory
+        attr_reader :request, :signature
+
+        def initialize(request)
+          @request = request
+        end
+
+        def sign
+          @signature = signer.sign(OpenSSL::Digest.new('SHA256'), request)
+        end
+
+        private
+
+        def signer
+          raise Google::AMP::Cache::PrivateKeyNotFound if private_key.blank?
+
+          OpenSSL::PKey::RSA.new(private_key)
+        end
+
+        def private_key
+          Google::AMP::Cache.configuration.private_key
+        end
+      end
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+class ConfigurationMinitest < Minitest::Test
+  describe 'default settings' do
+    describe '#amp_cache_domain' do
+      it 'defaults to cdn.ampproject.org' do
+        assert_equal('cdn.ampproject.org', Google::AMP::Cache::Configuration.new.amp_cache_domain)
+      end
+    end
+
+    describe '#private_key' do
+      it 'defaults to nil' do
+        assert_nil(Google::AMP::Cache::Configuration.new.private_key)
+      end
+    end
+  end
+
+  describe 'configure with provided block' do
+    before do
+      Google::AMP::Cache.configure do |config|
+        config.amp_cache_domain = 'bing-amp.com'
+        config.private_key = File.read("#{File.dirname(__FILE__)}/private-key.pem")
+      end
+    end
+
+    it 'sets configurations accordingly' do
+      assert_equal('bing-amp.com', Google::AMP::Cache.configuration.amp_cache_domain)
+      assert_equal(File.read("#{File.dirname(__FILE__)}/private-key.pem"), Google::AMP::Cache.configuration.private_key)
+    end
+  end
+
+  describe 'configure individually' do
+    before do
+      Google::AMP::Cache.configure do |config|
+        config.amp_cache_domain = 'cdn.ampproject.org'
+        config.private_key = 'dummy_key'
+      end
+    end
+
+    describe 'amp_cache_domain' do
+      it 'sets configuration accordingly' do
+        Google::AMP::Cache.configuration.amp_cache_domain = 'bing-amp.com'
+        assert_equal('bing-amp.com', Google::AMP::Cache.configuration.amp_cache_domain)
+      end
+
+      it 'does not touch unrelated settings' do
+        Google::AMP::Cache.configuration.amp_cache_domain = 'bing-amp.com'
+        assert_equal('dummy_key', Google::AMP::Cache.configuration.private_key)
+      end
+    end
+  end
+end

--- a/test/invalidator_test.rb
+++ b/test/invalidator_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+require 'openssl'
+
+class InvalidatorMinitest < Minitest::Test
+  describe '#ping' do
+    describe 'with correct key configured' do
+      before do
+        Google::AMP::Cache.configure do |config|
+          config.amp_cache_domain = 'cdn.ampproject.org'
+          config.private_key = File.read("#{File.dirname(__FILE__)}/private-key.pem")
+        end
+      end
+
+      it 'receive sucessful response' do
+        response = Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping
+        assert_equal('OK', response)
+      end
+    end
+
+    describe 'with incorrect key' do
+      before do
+        Google::AMP::Cache.configure do |config|
+          config.amp_cache_domain = 'cdn.ampproject.org'
+          config.private_key = OpenSSL::PKey::RSA.new(2048).to_s
+        end
+      end
+
+      it 'raises forbidden error' do
+        assert_raises Google::AMP::Cache::ForbiddenError do
+          Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping
+        end
+      end
+    end
+
+    describe 'with empty key' do
+      before do
+        Google::AMP::Cache.configure do |config|
+          config.amp_cache_domain = 'cdn.ampproject.org'
+          config.private_key = ''
+        end
+      end
+
+      it 'raises forbidden error' do
+        assert_raises Google::AMP::Cache::PrivateKeyNotFound do
+          Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping
+        end
+      end
+    end
+  end
+
+  describe 'with Bing as amp cache domain configured' do
+    before do
+      Timecop.freeze(Time.zone.at(1_600_685_360))
+      Google::AMP::Cache.configure do |config|
+        config.amp_cache_domain = 'bing-amp.com'
+        config.private_key = File.read("#{File.dirname(__FILE__)}/private-key.pem")
+      end
+    end
+
+    after do
+      Timecop.return
+      WebMock.disable!
+    end
+
+    it 'sends invalidate requests to Bing AMP CDN instead' do
+      stub_request(:get, 'https://limitless--tundra--65881-herokuapp-com.bing-amp.com/update-cache/c/s/limitless-tundra-65881.herokuapp.com/amp-access/sample/0?amp_action=flush&amp_ts=1600685360&amp_url_signature=CsQboBT-U0BynUXY_IQqhy-fUBLm9PGSvmRYIeHxrUoWaqgeOCvY2G7LA7gTBAnzqETiMPtPMfeSve3HhX9jKHQ6AcT_I4KNzC1p4xsntzmODBRZnlpOIa8zSZe2g-O51MNwf5U_gFmEHBBtATim5dUsOUFf8yWOiESSZnz2cpYFcKdjn656svx8wKZbnFe-4FG9n9U8YHLx9Qy4EXnxr0Bgo6HSEBQdbBigj97IDYcFWMtKUw0cxDr3JkKzNazTXj5wicoUEdW-Sur75HoIS9Ak0NgXKuAtPbb-QERtS-F7Lc8BKZg_sFPnqMNareYKriNmRuRAh0WEgdwj5fayUA')
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Host' => 'limitless--tundra--65881-herokuapp-com.bing-amp.com',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: 200, body: 'OK', headers: {})
+
+      assert_equal('OK', Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping)
+    end
+  end
+end

--- a/test/invalidator_test.rb
+++ b/test/invalidator_test.rb
@@ -7,6 +7,7 @@ class InvalidatorMinitest < Minitest::Test
   describe '#ping' do
     describe 'with correct key configured' do
       before do
+        WebMock.disable!
         Google::AMP::Cache.configure do |config|
           config.amp_cache_domain = 'cdn.ampproject.org'
           config.private_key = File.read("#{File.dirname(__FILE__)}/private-key.pem")
@@ -21,6 +22,7 @@ class InvalidatorMinitest < Minitest::Test
 
     describe 'with incorrect key' do
       before do
+        WebMock.disable!
         Google::AMP::Cache.configure do |config|
           config.amp_cache_domain = 'cdn.ampproject.org'
           config.private_key = OpenSSL::PKey::RSA.new(2048).to_s
@@ -36,6 +38,7 @@ class InvalidatorMinitest < Minitest::Test
 
     describe 'with empty key' do
       before do
+        WebMock.disable!
         Google::AMP::Cache.configure do |config|
           config.amp_cache_domain = 'cdn.ampproject.org'
           config.private_key = ''
@@ -52,7 +55,7 @@ class InvalidatorMinitest < Minitest::Test
 
   describe 'with Bing as amp cache domain configured' do
     before do
-      Timecop.freeze(Time.zone.at(1_600_685_360))
+      Timecop.freeze(Time.at(1_600_685_360))
       Google::AMP::Cache.configure do |config|
         config.amp_cache_domain = 'bing-amp.com'
         config.private_key = File.read("#{File.dirname(__FILE__)}/private-key.pem")
@@ -73,8 +76,7 @@ class InvalidatorMinitest < Minitest::Test
             'Host' => 'limitless--tundra--65881-herokuapp-com.bing-amp.com',
             'User-Agent' => 'Ruby'
           }
-        )
-        .to_return(status: 200, body: 'OK', headers: {})
+        ).to_return(status: 200, body: 'OK', headers: {})
 
       assert_equal('OK', Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping)
     end

--- a/test/invalidator_test.rb
+++ b/test/invalidator_test.rb
@@ -4,7 +4,7 @@ require_relative './test_helper'
 require 'openssl'
 
 class InvalidatorMinitest < Minitest::Test
-  describe '#ping' do
+  describe '#update_cache' do
     describe 'with correct key configured' do
       before do
         WebMock.disable!
@@ -15,7 +15,7 @@ class InvalidatorMinitest < Minitest::Test
       end
 
       it 'receive sucessful response' do
-        response = Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping
+        response = Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').update_cache
         assert_equal('OK', response)
       end
     end
@@ -31,7 +31,7 @@ class InvalidatorMinitest < Minitest::Test
 
       it 'raises forbidden error' do
         assert_raises Google::AMP::Cache::ForbiddenError do
-          Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping
+          Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').update_cache
         end
       end
     end
@@ -47,7 +47,7 @@ class InvalidatorMinitest < Minitest::Test
 
       it 'raises forbidden error' do
         assert_raises Google::AMP::Cache::PrivateKeyNotFound do
-          Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping
+          Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').update_cache
         end
       end
     end
@@ -64,7 +64,6 @@ class InvalidatorMinitest < Minitest::Test
 
     after do
       Timecop.return
-      WebMock.disable!
     end
 
     it 'sends invalidate requests to Bing AMP CDN instead' do
@@ -78,7 +77,9 @@ class InvalidatorMinitest < Minitest::Test
           }
         ).to_return(status: 200, body: 'OK', headers: {})
 
-      assert_equal('OK', Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').ping)
+      WebMock.disable!
+
+      assert_equal('OK', Google::AMP::Cache::Invalidator.new('https://limitless-tundra-65881.herokuapp.com/amp-access/sample/0').update_cache)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,7 @@ require 'minitest/reporters'
 Minitest::Reporters.use!
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
+require 'webmock/minitest'
+require 'timecop'
 require 'google/amp/cache'


### PR DESCRIPTION
## Why these changes?

While using the previous version, I've encountered the following setbacks while acting with the Client

### Dependencies
Version 0.2.0 depending on Faraday 1.x to work, however, lots of other gems still rely on Faraday 0.x to work

### Client serves multiple purposes
You can send AMP invalidation requests and query AMP URLs in the same class `Google::AMP::Cache::Client`, but the pass in params is different and ambiguous, and I don't want updates to AMP Validation request client to impact querying AMP URLs querying, so instead of modifying the original Client, I split invalidation request to be performed with the new Invalidator.

### Fixed Cache Domain 
I've noticed that there are several forks of this Gem just to support Bing AMP CDN Cache, with invalidation request splits in an isolated class, I also made a simple configuration for configuring the AMP cache domain to send invalidation request against.

### Failed in silence
Version 0.2.0 was moved to send requests with Faraday because we want to raise proper exceptions when things aren't going as expected. With the new Invalidator, it'll raise exceptions if PrivateKey is not configured, or not accepted by cache CDN.

### Miscellaneous
- Besides the above changes, I also add webmock and timcop just to test if requests are correctly sent based on configuration